### PR TITLE
fix: bugs report in Configuration class

### DIFF
--- a/src/main/java/fr/davidson/diff/jjoules/Configuration.java
+++ b/src/main/java/fr/davidson/diff/jjoules/Configuration.java
@@ -18,6 +18,7 @@ import fr.davidson.diff.jjoules.util.wrapper.WrapperEnum;
 import picocli.CommandLine;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -178,8 +179,10 @@ public class Configuration {
         if (!outputFd.isAbsolute()) {
             this.output = this.pathToFirstVersion + Constants.FILE_SEPARATOR + output;
         }
-        if (outputFd.exists()) {
-            outputFd.delete();
+        try {
+        	Files.deleteIfExists(outputFd.toPath());
+        } catch (Exception e) {
+        	throw new RuntimeException(String.format("Something went wrong when trying to delete the folder %s, please check your configuration", outputFd.toString()), e);
         }
         outputFd.mkdir();
         this.diff = new DiffComputer()

--- a/src/main/java/fr/davidson/diff/jjoules/Configuration.java
+++ b/src/main/java/fr/davidson/diff/jjoules/Configuration.java
@@ -180,9 +180,9 @@ public class Configuration {
             this.output = this.pathToFirstVersion + Constants.FILE_SEPARATOR + output;
         }
         try {
-        	Files.deleteIfExists(outputFd.toPath());
+            Files.deleteIfExists(outputFd.toPath());
         } catch (Exception e) {
-        	throw new RuntimeException(String.format("Something went wrong when trying to delete the folder %s, please check your configuration", outputFd.toString()), e);
+            throw new RuntimeException(String.format("Something went wrong when trying to delete the folder %s, please check your configuration", outputFd.toString()), e);
         }
         outputFd.mkdir();
         this.diff = new DiffComputer()

--- a/src/test/java/fr/davidson/diff/jjoules/ConfigurationTest.java
+++ b/src/test/java/fr/davidson/diff/jjoules/ConfigurationTest.java
@@ -1,0 +1,21 @@
+package fr.davidson.diff.jjoules;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.DirectoryNotEmptyException;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigurationTest {
+
+    @Test
+    void testDeleteOutputFdFailed() {
+        Exception e = assertThrows(RuntimeException.class, () -> {
+            new Configuration(null, null, 0, "src/test/resources/json", null, null, null, false, false, null, null, false);
+        });
+
+        String expectedMessage = String.format("Something went wrong when trying to delete the folder %s, please check your configuration", new File("src/test/resources/json").getPath());
+        assertEquals(expectedMessage, e.getMessage());
+        assertEquals(DirectoryNotEmptyException.class, e.getCause().getClass());
+    }
+}


### PR DESCRIPTION
Fixing bugs reported by Sonar #27
・[Do something with the "boolean" value returned by "delete".](https://sonarcloud.io/project/issues?id=davidson-consulting_diff-jjoules&open=AX1XhBZHPdBySudS67VD&resolved=false&types=BUG)

I've tried using java.nio.file.Files#deleteIfExists, what do you think?
If there are any problems, please point them out.